### PR TITLE
Implementation of method for adding new events incrementally.

### DIFF
--- a/test/runtest.py
+++ b/test/runtest.py
@@ -248,26 +248,6 @@ class tests(unittest.TestCase):
         self.assertAlmostEqual(post["b"].sigma,5.419,3)
         self.assertAlmostEqual(post["c"].mu,25.000,3)
         self.assertAlmostEqual(post["c"].sigma,5.419,3)
-    def test_add_events_batch(self):
-        pass
-        #agents= dict()
-        #for k in ["a", "b", "c", "d", "e", "f"]:
-            #agents[k] = ttt.Agent(ttt.Player(ttt.Gaussian(25., 25.0/3), 25.0/6, 25.0/300 ) , ttt.Ninf, -ttt.inf)
-        #composition = [ [["a"],["b"]], [["a"],["c"]] , [["b"],["c"]] ]
-        #results = [[1,0],[0,1],[1,0]]
-        #b = ttt.Batch(composition = composition, results = results, time=0, agents = agents)
-        #b.convergence()
-        #b.add_events(composition,results)
-        #self.assertEqual(len(b),6)
-        #post = b.posteriors()
-        #b.iteration(trace=True)
-        #b.iteration(trace=True)        
-        #self.assertAlmostEqual(post["a"].mu,25.000,3)
-        #self.assertAlmostEqual(post["a"].sigma,3.88,3)
-        #self.assertAlmostEqual(post["b"].mu,25.000,3)
-        #self.assertAlmostEqual(post["b"].sigma,3.88,3)
-        #self.assertAlmostEqual(post["c"].mu,25.000,3)
-        #self.assertAlmostEqual(post["c"].sigma,3.88,3)
     def test_history_init(self):
         composition = [ [["aa"],["b"]], [["aa"],["c"]] , [["b"],["c"]] ]
         results = [[1,0],[0,1],[1,0]]
@@ -579,6 +559,8 @@ class tests(unittest.TestCase):
         self.assertAlmostEqual(mu100, 6.555467)
         self.assertAlmostEqual(sigma100, 9.6449906)
 
+    ## add_history and add_events methods.
+
     def test_add_history(self):
         composition = [ [["a","b"],["c","d"]], [["e","f"] , ["b","c"]], [["a","d"], ["e","f"]]  ]
         results = [[1,0],[0,1],[1,0]]
@@ -589,6 +571,26 @@ class tests(unittest.TestCase):
         h.add_history(composition=[composition[2]], results=[results[2]],times=[times[2]])
         h.learning_curves()
 
+    def test_add_events_batch(self):
+        pass
+        #agents= dict()
+        #for k in ["a", "b", "c", "d", "e", "f"]:
+            #agents[k] = ttt.Agent(ttt.Player(ttt.Gaussian(25., 25.0/3), 25.0/6, 25.0/300 ) , ttt.Ninf, -ttt.inf)
+        #composition = [ [["a"],["b"]], [["a"],["c"]] , [["b"],["c"]] ]
+        #results = [[1,0],[0,1],[1,0]]
+        #b = ttt.Batch(composition = composition, results = results, time=0, agents = agents)
+        #b.convergence()
+        #b.add_events(composition,results)
+        #self.assertEqual(len(b),6)
+        #post = b.posteriors()
+        #b.iteration(trace=True)
+        #b.iteration(trace=True)
+        #self.assertAlmostEqual(post["a"].mu,25.000,3)
+        #self.assertAlmostEqual(post["a"].sigma,3.88,3)
+        #self.assertAlmostEqual(post["b"].mu,25.000,3)
+        #self.assertAlmostEqual(post["b"].sigma,3.88,3)
+        #self.assertAlmostEqual(post["c"].mu,25.000,3)
+        #self.assertAlmostEqual(post["c"].sigma,3.88,3)
 
     def ToDo(self):
         print("Ningun toDo")

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -578,6 +578,18 @@ class tests(unittest.TestCase):
         mu100, sigma100 = h.batches[0].posterior("a")
         self.assertAlmostEqual(mu100, 6.555467)
         self.assertAlmostEqual(sigma100, 9.6449906)
+
+    def test_add_history(self):
+        composition = [ [["a","b"],["c","d"]], [["e","f"] , ["b","c"]], [["a","d"], ["e","f"]]  ]
+        results = [[1,0],[0,1],[1,0]]
+        times =[100,300,500]
+        h = ttt.History(composition=[composition[0]], results=[results[0]],times=[times[0]], mu=0.0,sigma=6.0, beta=1.0, gamma=0.0)
+        h.convergence()
+        h.add_history(composition=[composition[1]], results=[results[1]],times=[times[1]])
+        h.add_history(composition=[composition[2]], results=[results[2]],times=[times[2]])
+        h.learning_curves()
+
+
     def ToDo(self):
         print("Ningun toDo")
         

--- a/trueskillthroughtime/__init__.py
+++ b/trueskillthroughtime/__init__.py
@@ -546,10 +546,11 @@ class History(object):
         if (len(weights) > 0) and (len(composition) != len(weights)): raise ValueError("(length(weights) > 0) & (length(composition) != length(weights))")
         if self.time is None:
             self.time = len(times) > 0
+            self.latest_time = max(times)
         else:
             if self.time is True:
                 if len(times) == 0: raise ValueError(" len(times) error ")
-                if min(times) > self.latest_time: raise ValueError(" len(times) error ")
+                self.latest_time = max(times)
             else:
                 if len(times) > 0: raise ValueError(" len(times) error ")
         self.size += len(composition)
@@ -562,8 +563,7 @@ class History(object):
                 p = Player(Gaussian(self.mu, self.sigma), self.beta, self.gamma)
             self.agents[a] = Agent(p, Ninf, -inf)
         self.trueskill(composition,results,times, weights)
-        if self.time:
-            self.latest_time = max(times)
+
     def trueskill(self, composition, results, times, weights):
         o = sortperm(times) if len(times)>0 else [i for i in range(len(composition))]
         i = 0

--- a/trueskillthroughtime/__init__.py
+++ b/trueskillthroughtime/__init__.py
@@ -525,24 +525,45 @@ class Batch(object):
 
 class History(object):
     def __init__(self,composition, results=[], times=[], priors=dict(), mu=MU, sigma=SIGMA, beta=BETA, gamma=GAMMA, p_draw=P_DRAW, weights=[]):
-        if (len(results) > 0) and (len(composition) != len(results)): raise ValueError("len(composition) != len(results)")
-        if (len(times) > 0) and (len(composition) != len(times)): raise ValueError(" len(times) error ")
-        if (len(weights) > 0) and (len(composition) != len(weights)): raise ValueError("(length(weights) > 0) & (length(composition) != length(weights))")
-            
-        self.size = len(composition)
+        self.size = 0
         self.batches = []
-        self.agents = dict([ (a, Agent(priors[a] if a in priors else Player(Gaussian(mu, sigma), beta, gamma), Ninf, -inf)) for a in set( [a for teams in composition for team in teams for a in team] ) ])
+        self.agents = dict()
         self.mu = mu
         self.sigma = sigma
+        self.beta = beta
         self.gamma = gamma
         self.p_draw = p_draw
-        self.time = len(times)>0
-        self.trueskill(composition,results,times, weights)
-        
+        self.time = None
+        self.latest_time = 0
+        self.add_history(composition, results, times, priors, weights)
     def __repr__(self):
         return "History(Events={}, Batches={}, Agents={})".format(self.size,len(self.batches),len(self.agents))
     def __len__(self):
         return self.size
+    def add_history(self, composition, results=[], times=[], priors=dict(), weights=[]):
+        if (len(results) > 0) and (len(composition) != len(results)): raise ValueError("len(composition) != len(results)")
+        if (len(times) > 0) and (len(composition) != len(times)): raise ValueError(" len(times) error ")
+        if (len(weights) > 0) and (len(composition) != len(weights)): raise ValueError("(length(weights) > 0) & (length(composition) != length(weights))")
+        if self.time is None:
+            self.time = len(times) > 0
+        else:
+            if self.time is True:
+                if len(times) == 0: raise ValueError(" len(times) error ")
+                if min(times) > self.latest_time: raise ValueError(" len(times) error ")
+            else:
+                if len(times) > 0: raise ValueError(" len(times) error ")
+        self.size += len(composition)
+        for a in set( [a for teams in composition for team in teams for a in team] ):
+            if a in self.agents:
+                continue
+            if a in priors:
+                p = priors[a]
+            else:
+                p = Player(Gaussian(self.mu, self.sigma), self.beta, self.gamma)
+            self.agents[a] = Agent(p, Ninf, -inf)
+        self.trueskill(composition,results,times, weights)
+        if self.time:
+            self.latest_time = max(times)
     def trueskill(self, composition, results, times, weights):
         o = sortperm(times) if len(times)>0 else [i for i in range(len(composition))]
         i = 0


### PR DESCRIPTION
I have separated the addition process of competitions into the `add_history` method. This modification allows for incremental addition of competitions.

The existing interface remains unchanged.

To prevent inappropriate updating of last_time in agents, each newly added competition is compared with the `min(times)` of all previously added competitions. This check ensures that every newly added competition occurs after all competitions added prior to it.

Do we need to create new tests for this feature?

Thank you for your review!